### PR TITLE
Update jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.8</version>
+			<version>2.9.9</version>
 		</dependency>
 
 		<!-- Test scope -->


### PR DESCRIPTION
Update `jackson-databind` to version `2.9.9`. The new version includes a fix for security vulnerability `CVE-2019-12086`.