### PR TITLE
update jackson-databind to version 2.9.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9</version>
+			<version>2.9.9.2</version>
 		</dependency>
 
 		<!-- Test scope -->


### PR DESCRIPTION
Update `jackson-databind` to version `2.9.9.2` to fix security vulnerabilities.