### PR TITLE
Use openjdk8 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+dist: xenial
+
 language: java
 
 sudo: false
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Use `openjdk8` in CI instead of `oraclejdk8`.